### PR TITLE
Fix style for ads section in user profile

### DIFF
--- a/views/user.ejs
+++ b/views/user.ejs
@@ -540,6 +540,13 @@ progress {
       }
     }
 
+    .ads-info {
+      background-color: #e6f7ff;
+      padding: 10px;
+      border-radius: 5px;
+      margin-bottom: 15px;
+    }
+
     </style>
 </head>
 <body id="top">
@@ -725,16 +732,18 @@ progress {
     <hr class="my-4">
 
     <!-- Vos Annonces -->
-    <p class="card-text"><strong><%= i18n.your_ads %></strong></p>
-    <% if (userLandingPages && userLandingPages.length > 0) { %>
-      <p class="card-text"><%= i18n.ads_generated.replace('{count}', userLandingPages.length) %></p>
-      <p class="card-text"><%= i18n.remember_to_publish %></p>
-    <% } else { %>
-      <p class="card-text"><%= i18n.no_ads_yet %></p>
-      <a href="#" onclick="showSection('landing')" class="btn btn-sm btn-outline-dark mt-2">
-        <i class="bi bi-plus-circle"></i><%= i18n.create_first_ad %>
-      </a>
-    <% } %>
+    <div class="ads-info">
+      <p class="card-text"><strong><%= i18n.your_ads %></strong></p>
+      <% if (userLandingPages && userLandingPages.length > 0) { %>
+        <p class="card-text"><%- i18n.ads_generated.replace('{count}', userLandingPages.length) %></p>
+        <p class="card-text"><%- i18n.remember_to_publish %></p>
+      <% } else { %>
+        <p class="card-text"><%= i18n.no_ads_yet %></p>
+        <a href="#" onclick="showSection('landing')" class="btn btn-sm btn-outline-dark mt-2">
+          <i class="bi bi-plus-circle"></i><%= i18n.create_first_ad %>
+        </a>
+      <% } %>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- style the ads section with a light blue background
- ensure translation HTML is rendered instead of escaped

## Testing
- `node test-auth.js` *(fails: Cannot find module 'googleapis')*
- `node test-analytics.js` *(fails: Cannot find module 'googleapis')*

------
https://chatgpt.com/codex/tasks/task_e_684044fb53cc8328b00d8453ee1137a8