### PR TITLE
Make publish reminder link to created pages

### DIFF
--- a/locales/en/user.json
+++ b/locales/en/user.json
@@ -52,7 +52,7 @@
   "edit": "Edit",
   "your_ads": "Your Ads",
   "ads_generated": "You have generated <strong>{count}</strong> property ad page(s).",
-  "remember_to_publish": "Don't forget to <strong>publish</strong> your ads for more visibility!",
+  "remember_to_publish": "Don't forget to <strong><a href=\"#\" onclick=\"showSection('created-pages')\">publish</a></strong> your ads for more visibility!",
   "no_ads_yet": "You haven't generated any ad yet.",
   "create_first_ad": "Create my first ad",
   "step1_title": "General property information",

--- a/locales/fr/user.json
+++ b/locales/fr/user.json
@@ -52,7 +52,7 @@
   "edit": "Modifier",
   "your_ads": "Vos Annonces",
   "ads_generated": "✅ Vous avez généré <strong>{count}</strong> page(s) d'annonce immobilière.",
-  "remember_to_publish": "📣 N'oubliez pas de <strong>diffuser</strong> vos annonces pour plus de visibilité !",
+  "remember_to_publish": "📣 N'oubliez pas de <strong><a href=\"#\" onclick=\"showSection('created-pages')\">diffuser</a></strong> vos annonces pour plus de visibilité !",
   "no_ads_yet": "🚫 Vous n'avez pas encore généré d'annonce.",
   "create_first_ad": "Créer ma première annonce",
   "step1_title": "Informations générales du bien",


### PR DESCRIPTION
## Summary
- make the "remember to publish" reminder a clickable link to the created pages section

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68404f87e3e88328bf9376fc29882d7b