### PR TITLE
Fix password reset routing

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -8,6 +8,7 @@ const UserSchema = new mongoose.Schema({
   role: { type: String, required: true },
   resetPasswordToken: String,
   resetPasswordExpires: Date,
+  resetPasswordCode: String,
   twoFactorSecret: { type: String }, // Secret utilisé pour la 2FA (Google Authenticator)
   twoFactorEnabled: { type: Boolean, default: false } // Indique si 2FA est activé ou non
 });

--- a/server.js
+++ b/server.js
@@ -489,39 +489,14 @@ app.post('/:lang/forgot-password', async (req, res) => {
     }
 
     const token = crypto.randomBytes(32).toString('hex');
+    const code = Math.floor(100000 + Math.random() * 900000).toString();
     user.resetPasswordToken = token;
     user.resetPasswordExpires = Date.now() + 3600000; // 1 heure
+    user.resetPasswordCode = code;
     await user.save();
 
     const resetUrl = `http://${req.headers.host}/${locale}/reset-password/${token}`;
-    const mailOptions = {
-      to: user.email,
-      from: process.env.EMAIL_USER,
-      subject: 'Réinitialisation du mot de passe',
-      html: `
-        <div style="font-family: Arial, sans-serif; line-height: 1.6;">
-          <h2 style="color: #52566f;">Réinitialisation de votre mot de passe</h2>
-          <p>Bonjour,</p>
-          <p>Nous avons reçu une demande de réinitialisation du mot de passe associé à votre compte UAP Immo.</p>
-          
-          <p style="font-size: 16px; color: #52566f;">Que devez-vous faire ?</p>
-          <p>Pour réinitialiser votre mot de passe, veuillez cliquer sur le lien ci-dessous :</p>
-          <p><a href="${resetUrl}" style="color: #52566f; text-decoration: underline;">Réinitialiser mon mot de passe</a></p>
-    
-          <p>Ce lien est valide pendant 1 heure. Si vous n'avez pas fait cette demande, vous pouvez ignorer cet email en toute sécurité.</p>
-    
-          <p style="font-size: 16px; color: #52566f;">Besoin d'aide ?</p>
-          <p>Si vous avez des questions ou avez besoin d'aide, n'hésitez pas à nous contacter à <a href="mailto:support@uap.company" style="color: #52566f; text-decoration: underline;">support@uap.company</a>.</p>
-    
-          <p>Cordialement,</p>
-          <p>L'équipe UAP Immo</p>
-          
-          <hr>
-          <p style="font-size: 12px; color: #888;">Cet email a été envoyé automatiquement, merci de ne pas y répondre. Pour toute assistance, contactez-nous à <a href="mailto:support@uap.company" style="color: #52566f; text-decoration: underline;">support@uap.company</a>.</p>
-        </div>
-      `
-    };
-    await sendEmail(mailOptions);
+    await sendPasswordResetEmail(user, locale, resetUrl, code);
 
     req.flash('success', 'Un email avec des instructions pour réinitialiser votre mot de passe a été envoyé.');
     return res.redirect(`/${locale}/forgot-password?emailSent=true`);
@@ -533,6 +508,12 @@ app.post('/:lang/forgot-password', async (req, res) => {
 });
 
 app.get('/reset-password/:token', async (req, res) => {
+  const locale = req.locale || 'fr';
+  return res.redirect(`/${locale}/reset-password/${req.params.token}`);
+});
+
+app.get('/:lang/reset-password/:token', async (req, res) => {
+  const locale = req.params.lang;
   try {
     const user = await User.findOne({
       resetPasswordToken: req.params.token,
@@ -544,16 +525,22 @@ app.get('/reset-password/:token', async (req, res) => {
       return res.redirect('/forgot-password');
     }
 
-    res.render('reset-password', { token: req.params.token });
+    res.render('reset-password', { token: req.params.token, locale });
   } catch (error) {
     console.error('Erreur lors de la vérification du token :', error);
     req.flash('error', 'Une erreur est survenue lors de la vérification du token.');
-    res.redirect('/forgot-password');
+    res.redirect(`/${locale}/forgot-password`);
   }
 });
 
 app.post('/reset-password/:token', async (req, res) => {
-  const { password, confirmPassword } = req.body;
+  const locale = req.locale || 'fr';
+  return res.redirect(`/${locale}/reset-password/${req.params.token}`);
+});
+
+app.post('/:lang/reset-password/:token', async (req, res) => {
+  const { password, confirmPassword, code } = req.body;
+  const locale = req.params.lang;
 
   if (password !== confirmPassword) {
     req.flash('error', 'Les mots de passe ne correspondent pas.');
@@ -568,7 +555,12 @@ app.post('/reset-password/:token', async (req, res) => {
 
     if (!user) {
       req.flash('error', 'Le token de réinitialisation est invalide ou a expiré.');
-      return res.redirect('/forgot-password');
+      return res.redirect(`/${locale}/forgot-password`);
+    }
+
+    if (user.resetPasswordCode !== code) {
+      req.flash('error', locale === 'fr' ? 'Code de vérification incorrect.' : 'Invalid verification code.');
+      return res.redirect('back');
     }
 
     user.setPassword(password, async (err) => {
@@ -579,15 +571,16 @@ app.post('/reset-password/:token', async (req, res) => {
 
       user.resetPasswordToken = undefined;
       user.resetPasswordExpires = undefined;
+      user.resetPasswordCode = undefined;
       await user.save();
 
       req.flash('success', 'Votre mot de passe a été mis à jour avec succès.');
-      res.redirect('/login');
+      res.redirect(`/${locale}/login`);
     });
   } catch (error) {
     console.error('Erreur lors de la mise à jour du mot de passe :', error);
     req.flash('error', 'Une erreur est survenue lors de la mise à jour du mot de passe.');
-    res.redirect('/forgot-password');
+    res.redirect(`/${locale}/forgot-password`);
   }
 });
 
@@ -2196,6 +2189,36 @@ async function sendAccountCreationEmail(email, firstName, lastName, locale = 'fr
         <p style="font-size: 12px; color: #888;">Cet email a été envoyé automatiquement. Merci de ne pas y répondre. Pour toute assistance, contactez-nous à <a href="mailto:support@uap.company">support@uap.company</a>.</p>
       </div>
     `
+  };
+
+  await sendEmail(mailOptions);
+}
+
+async function sendPasswordResetEmail(user, locale, resetUrl, code) {
+  const isFr = locale === 'fr';
+  const subject = isFr ? 'Réinitialisation du mot de passe' : 'Password Reset';
+  const html = `
+    <div style="font-family: Arial, sans-serif; line-height: 1.6;">
+      <h2 style="color: #52566f;">${isFr ? 'Réinitialisation de votre mot de passe' : 'Password Reset'}</h2>
+      <p>${isFr ? 'Bonjour,' : 'Hello,'}</p>
+      <p>${isFr ? 'Vous avez demandé à réinitialiser le mot de passe de votre compte UAP Immo.' : 'You requested to reset the password for your UAP Immo account.'}</p>
+      <p>${isFr ? 'Utilisez le code suivant pour confirmer votre demande :' : 'Use the following code to confirm your request:'}</p>
+      <p style="font-size: 24px; font-weight: bold; color: #52566f;">${code}</p>
+      <p>${isFr ? 'Ou cliquez sur le lien ci-dessous pour définir un nouveau mot de passe :' : 'Or click the link below to set a new password:'}</p>
+      <p><a href="${resetUrl}" style="color: #52566f; text-decoration: underline;">${isFr ? 'Réinitialiser mon mot de passe' : 'Reset my password'}</a></p>
+      <p>${isFr ? 'Ce code et ce lien expirent dans 1 heure.' : 'This code and link are valid for 1 hour.'}</p>
+      <p>${isFr ? "Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet email." : 'If you did not make this request, you can ignore this email.'}</p>
+      <p>${isFr ? 'Cordialement,<br>L\'équipe UAP Immo' : 'Regards,<br>The UAP Immo Team'}</p>
+      <hr>
+      <p style="font-size: 12px; color: #888;">${isFr ? 'Cet email a été envoyé automatiquement. Merci de ne pas y répondre.' : 'This email was sent automatically. Please do not reply.'}</p>
+    </div>
+  `;
+
+  const mailOptions = {
+    from: `"UAP Immo" <${process.env.EMAIL_USER}>`,
+    to: user.email,
+    subject,
+    html
   };
 
   await sendEmail(mailOptions);

--- a/views/forgot-password.ejs
+++ b/views/forgot-password.ejs
@@ -167,7 +167,7 @@
                             <% } %>
 
                             <% if (!messages.success) { %>
-                                <form action="/forgot-password" method="POST">
+                                <form action="/<%= locale %>/forgot-password" method="POST">
                                     <div class="mb-3">
                                         <label for="email" class="form-label"><%= i18n.email %></label>
                                         <input type="email" class="form-control" id="email" name="email" required>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -319,7 +319,7 @@ footer .copyright-text {
   </div>
 <% } %>
               <div class="mt-3 text-center">
-                <a href="/forgot-password"><%= i18n.forgot_password %></a>
+                <a href="/<%= locale %>/forgot-password"><%= i18n.forgot_password %></a>
               </div>
            <div class="mt-3 text-center">
     <span><%= i18n.register_prompt %> <a href="/<%= locale %>/register"><%= i18n.register_link %></a></span>

--- a/views/reset-password.ejs
+++ b/views/reset-password.ejs
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="<%= locale %>">
 <head>
  <!-- Google tag (gtag.js) -->
    <!-- Google Tag Manager -->
@@ -145,7 +145,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                         <div class="col-12 col-lg-8 mx-auto">
                             <div class="form-container">
                                 <h2 class="text-center">Définir un nouveau mot de passe</h2>
-                  <form action="/reset-password/<%= token %>" method="POST">
+                  <form action="/<%= locale %>/reset-password/<%= token %>" method="POST">
     <div class="mb-3">
         <label for="password" class="form-label">Nouveau mot de passe</label>
         <input type="password" class="form-control" id="password" name="password" required>
@@ -154,11 +154,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <label for="confirmPassword" class="form-label">Confirmer le mot de passe</label>
         <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" required>
     </div>
+    <div class="mb-3">
+        <label for="code" class="form-label"><%= locale === 'fr' ? 'Code reçu par mail' : 'Email code' %></label>
+        <input type="text" class="form-control" id="code" name="code" required>
+    </div>
     <button type="submit" class="btn btn-primary">Réinitialiser le mot de passe</button>
 </form>
 
                                 <div class="mt-3 text-center">
-    <a href="/forgot-password">Mot de passe oublié ?</a>
+    <a href="/<%= locale %>/forgot-password">Mot de passe oublié ?</a>
 </div>
 
                                 


### PR DESCRIPTION
## Summary
- fix reset password form links to use locale-aware paths
- add localized reset-password routes
- redirect old reset-password paths
- add email validation code for password resets

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684081d5d6988328a2126d533e6cfe54