### PR TITLE
Improve reset password flow

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -8,6 +8,7 @@ const UserSchema = new mongoose.Schema({
   role: { type: String, required: true },
   resetPasswordToken: String,
   resetPasswordExpires: Date,
+  resetPasswordCode: String,
   twoFactorSecret: { type: String }, // Secret utilisé pour la 2FA (Google Authenticator)
   twoFactorEnabled: { type: Boolean, default: false } // Indique si 2FA est activé ou non
 });

--- a/views/forgot-password.ejs
+++ b/views/forgot-password.ejs
@@ -167,7 +167,7 @@
                             <% } %>
 
                             <% if (!messages.success) { %>
-                                <form action="/forgot-password" method="POST">
+                                <form action="/<%= locale %>/forgot-password" method="POST">
                                     <div class="mb-3">
                                         <label for="email" class="form-label"><%= i18n.email %></label>
                                         <input type="email" class="form-control" id="email" name="email" required>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -319,7 +319,7 @@ footer .copyright-text {
   </div>
 <% } %>
               <div class="mt-3 text-center">
-                <a href="/forgot-password"><%= i18n.forgot_password %></a>
+                <a href="/<%= locale %>/forgot-password"><%= i18n.forgot_password %></a>
               </div>
            <div class="mt-3 text-center">
     <span><%= i18n.register_prompt %> <a href="/<%= locale %>/register"><%= i18n.register_link %></a></span>

--- a/views/reset-password.ejs
+++ b/views/reset-password.ejs
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="<%= locale %>">
 <head>
  <!-- Google tag (gtag.js) -->
    <!-- Google Tag Manager -->
@@ -81,6 +81,46 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .navbar .navbar-icon.bi-person {
             color: #000 !important;
         }
+        .label-info {
+            position: relative;
+            display: inline-block;
+            margin-left: 5px;
+            color: #888;
+            cursor: pointer;
+        }
+        .label-info::after {
+            content: attr(data-info);
+            position: absolute;
+            width: max-content;
+            min-width: 180px;
+            top: -5px;
+            left: 120%;
+            z-index: 10;
+            background: #fff;
+            color: #000;
+            border: 1px solid #ddd;
+            padding: 8px 10px;
+            border-radius: 6px;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+            font-size: 0.85rem;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: normal;
+        }
+        .label-info:hover::after {
+            opacity: 1;
+        }
+        .password-match-message {
+            font-size: 0.85rem;
+            margin-top: 5px;
+        }
+        .password-match-message.success {
+            color: #28a745;
+        }
+        .password-match-message.error {
+            color: #dc3545;
+        }
         @media (max-width: 767px) {
             .form-container {
                 background: none;
@@ -145,20 +185,51 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                         <div class="col-12 col-lg-8 mx-auto">
                             <div class="form-container">
                                 <h2 class="text-center">Définir un nouveau mot de passe</h2>
-                  <form action="/reset-password/<%= token %>" method="POST">
+                  <form action="/<%= locale %>/reset-password/<%= token %>" method="POST">
     <div class="mb-3">
-        <label for="password" class="form-label">Nouveau mot de passe</label>
-        <input type="password" class="form-control" id="password" name="password" required>
+        <label for="password" class="form-label">
+          Nouveau mot de passe
+          <span class="label-info" data-info="<%= i18n.password_help %>">
+            <i class="bi bi-info-circle-fill" aria-label="Information"></i>
+          </span>
+        </label>
+        <div class="input-group">
+          <input type="password" class="form-control" id="password" name="password" required>
+          <div class="input-group-append">
+            <span class="input-group-text toggle-password" id="togglePassword"><i class="bi bi-eye"></i></span>
+          </div>
+        </div>
+        <div id="passwordStrength" class="password-match-message mt-1"></div>
     </div>
     <div class="mb-3">
-        <label for="confirmPassword" class="form-label">Confirmer le mot de passe</label>
-        <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" required>
+        <label for="confirmPassword" class="form-label">
+          Confirmer le mot de passe
+          <span class="label-info" data-info="Ressaisissez exactement le même mot de passe pour confirmation.">
+            <i class="bi bi-info-circle-fill" aria-label="Information"></i>
+          </span>
+        </label>
+        <div class="input-group">
+          <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" required>
+          <div class="input-group-append">
+            <span class="input-group-text toggle-password" id="toggleConfirmPassword"><i class="bi bi-eye"></i></span>
+          </div>
+        </div>
+        <div id="passwordMatchMessage" class="password-match-message mt-1"></div>
+    </div>
+    <div class="mb-3">
+        <label for="code" class="form-label"><%= locale === 'fr' ? 'Code reçu par mail' : 'Email code' %></label>
+        <input type="text" class="form-control" id="code" name="code" required>
     </div>
     <button type="submit" class="btn btn-primary">Réinitialiser le mot de passe</button>
 </form>
+<% if (messages.error && messages.error.length > 0) { %>
+  <div class="alert alert-danger mt-3">
+    <%= messages.error[0] %>
+  </div>
+<% } %>
 
                                 <div class="mt-3 text-center">
-    <a href="/forgot-password">Mot de passe oublié ?</a>
+    <a href="/<%= locale %>/forgot-password">Mot de passe oublié ?</a>
 </div>
 
                                 
@@ -217,12 +288,92 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <!-- <script src="/js/click-scroll.js"></script> -->
         <script src="/js/custom.js"></script>
         <script>
-            document.getElementById('togglePassword').addEventListener('click', function (e) {
-                const passwordInput = document.getElementById('password');
-                const type = passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
-                passwordInput.setAttribute('type', type);
-                this.classList.toggle('bi-eye-fill');
-                this.classList.toggle('bi-eye-slash-fill');
+            function handlePasswordToggle(buttonId, inputId) {
+                const toggleBtn = document.getElementById(buttonId);
+                const input = document.getElementById(inputId);
+                const icon = toggleBtn.querySelector('i');
+
+                icon.style.transition = 'transform 0.2s ease, opacity 0.2s ease';
+
+                toggleBtn.addEventListener('mousedown', () => {
+                    input.type = 'text';
+                    icon.classList.remove('bi-eye');
+                    icon.classList.add('bi-eye-slash');
+                    icon.style.transform = 'scale(1.2)';
+                    icon.style.opacity = '0.7';
+                });
+
+                toggleBtn.addEventListener('mouseup', () => {
+                    input.type = 'password';
+                    icon.classList.remove('bi-eye-slash');
+                    icon.classList.add('bi-eye');
+                    icon.style.transform = 'scale(1)';
+                    icon.style.opacity = '1';
+                });
+
+                toggleBtn.addEventListener('mouseleave', () => {
+                    input.type = 'password';
+                    icon.classList.remove('bi-eye-slash');
+                    icon.classList.add('bi-eye');
+                    icon.style.transform = 'scale(1)';
+                    icon.style.opacity = '1';
+                });
+            }
+
+            handlePasswordToggle('togglePassword', 'password');
+            handlePasswordToggle('toggleConfirmPassword', 'confirmPassword');
+
+            const password = document.getElementById('password');
+            const confirmPassword = document.getElementById('confirmPassword');
+            const messageDiv = document.getElementById('passwordMatchMessage');
+            const passwordStrength = document.getElementById('passwordStrength');
+
+            function checkPasswordMatch() {
+                if (confirmPassword.value === '') {
+                    messageDiv.textContent = '';
+                    confirmPassword.setCustomValidity('');
+                    return;
+                }
+
+                if (confirmPassword.value !== password.value) {
+                    messageDiv.textContent = '<%= i18n.password_validation.mismatch %>';
+                    messageDiv.className = 'password-match-message error';
+                    confirmPassword.setCustomValidity('<%= i18n.password_validation.mismatch %>');
+                } else {
+                    messageDiv.textContent = '<%= i18n.password_validation.match %>';
+                    messageDiv.className = 'password-match-message success';
+                    confirmPassword.setCustomValidity('');
+                }
+            }
+
+            password.addEventListener('input', checkPasswordMatch);
+            confirmPassword.addEventListener('input', checkPasswordMatch);
+
+            password.addEventListener('input', function () {
+                const value = password.value;
+                let strength = 0;
+
+                if (value.length >= 8) strength++;
+                if (/[A-Z]/.test(value)) strength++;
+                if (/[0-9]/.test(value)) strength++;
+                if (/[^A-Za-z0-9]/.test(value)) strength++;
+
+                switch (strength) {
+                    case 0:
+                    case 1:
+                        passwordStrength.textContent = '<%= i18n.password_validation.too_weak %>';
+                        passwordStrength.className = 'password-match-message error';
+                        break;
+                    case 2:
+                    case 3:
+                        passwordStrength.textContent = '<%= i18n.password_validation.medium %>';
+                        passwordStrength.className = 'password-match-message';
+                        break;
+                    case 4:
+                        passwordStrength.textContent = '<%= i18n.password_validation.strong %>';
+                        passwordStrength.className = 'password-match-message success';
+                        break;
+                }
             });
         </script>
     </body>


### PR DESCRIPTION
## Summary
- load register translations for reset password page
- send bilingual password reset emails
- add password strength meter and show/hide toggle to reset page
- display verification code errors on reset page

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684081d5d6988328a2126d533e6cfe54