### PR TITLE
Add password visibility toggle to reset page

### DIFF
--- a/views/reset-password.ejs
+++ b/views/reset-password.ejs
@@ -148,11 +148,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                   <form action="/<%= locale %>/reset-password/<%= token %>" method="POST">
     <div class="mb-3">
         <label for="password" class="form-label">Nouveau mot de passe</label>
-        <input type="password" class="form-control" id="password" name="password" required>
+        <div class="form-control-icon">
+            <input type="password" class="form-control" id="password" name="password" required>
+            <i class="bi bi-eye-fill icon" id="togglePassword"></i>
+        </div>
     </div>
     <div class="mb-3">
         <label for="confirmPassword" class="form-label">Confirmer le mot de passe</label>
-        <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" required>
+        <div class="form-control-icon">
+            <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" required>
+            <i class="bi bi-eye-fill icon" id="toggleConfirmPassword"></i>
+        </div>
     </div>
     <div class="mb-3">
         <label for="code" class="form-label"><%= locale === 'fr' ? 'Code reçu par mail' : 'Email code' %></label>
@@ -221,10 +227,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <!-- <script src="/js/click-scroll.js"></script> -->
         <script src="/js/custom.js"></script>
         <script>
-            document.getElementById('togglePassword').addEventListener('click', function (e) {
+            document.getElementById('togglePassword').addEventListener('click', function () {
                 const passwordInput = document.getElementById('password');
                 const type = passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
                 passwordInput.setAttribute('type', type);
+                this.classList.toggle('bi-eye-fill');
+                this.classList.toggle('bi-eye-slash-fill');
+            });
+            document.getElementById('toggleConfirmPassword').addEventListener('click', function () {
+                const confirmInput = document.getElementById('confirmPassword');
+                const type = confirmInput.getAttribute('type') === 'password' ? 'text' : 'password';
+                confirmInput.setAttribute('type', type);
                 this.classList.toggle('bi-eye-fill');
                 this.classList.toggle('bi-eye-slash-fill');
             });


### PR DESCRIPTION
## Summary
- allow toggling visibility for password fields on the reset password form

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68409ca3c8cc832896aa3df3ac381783