### PR TITLE
Fix forgot password navbar

### DIFF
--- a/locales/en/password-reset.json
+++ b/locales/en/password-reset.json
@@ -12,6 +12,9 @@
     "processus": "Process",
     "faq": "FAQs",
     "contact": "Contact",
-    "login": "Login"
+    "login": "Login",
+    "my_account": "My Account",
+    "logout": "Logout",
+    "register": "Register"
   }
 }

--- a/locales/fr/password-reset.json
+++ b/locales/fr/password-reset.json
@@ -12,6 +12,9 @@
     "processus": "Processus",
     "faq": "FAQs",
     "contact": "Contact",
-    "login": "Connexion"
+    "login": "Connexion",
+    "my_account": "Mon compte",
+    "logout": "Déconnexion",
+    "register": "Créer un compte"
   }
 }

--- a/views/forgot-password.ejs
+++ b/views/forgot-password.ejs
@@ -78,6 +78,29 @@
         .navbar .navbar-icon.bi-person {
             color: #000 !important;
         }
+        .lang-flag {
+            width: 24px;
+            height: 16px;
+            background-size: contain;
+            background-repeat: no-repeat;
+            background-position: center;
+            display: inline-block;
+            flex-shrink: 0;
+        }
+        .lang-fr {
+            background-image: url('https://flagcdn.com/fr.svg');
+        }
+        .lang-en {
+            background-image: url('https://flagcdn.com/gb.svg');
+        }
+        .navbar .btn-outline-dark:hover {
+            background-color: #52566f;
+            color: #fff;
+            border-color: #52566f;
+        }
+        .navbar .btn-outline-dark {
+            margin-right: 12px;
+        }
         @media (max-width: 767px) {
             .form-container {
                 background: none;
@@ -85,73 +108,117 @@
                 border: none;
             }
         }
-    </style>    
+        @media (max-width: 991.98px) {
+            .mobile-lang-selector {
+                display: flex !important;
+                align-items: center;
+                gap: 8px;
+            }
+            .desktop-lang-selector {
+                display: none !important;
+            }
+        }
+        @media (min-width: 992px) {
+            .mobile-lang-selector {
+                display: none !important;
+            }
+        }
+    </style>
 </head>
 <body id="top">
   <main>
-     <nav class="navbar navbar-expand-lg fixed-top">
-  <div class="container">
-    <a class="navbar-brand" href="/<%= locale %>">
-      <span>UAP Immo</span>
-    </a>
+    <% let cleanPath = currentPath.replace(/^\/(fr|en)/, '') || '/'; %>
+    <nav class="navbar navbar-expand-lg fixed-top">
+      <div class="container">
+        <!-- Logo -->
+        <a class="navbar-brand" href="/<%= locale %>">
+          <span>UAP Immo</span>
+        </a>
 
-    <!-- Bouton Burger -->
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
-      aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
+        <!-- Burger -->
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
 
-    <!-- Menu collapsé -->
-    <div class="collapse navbar-collapse" id="navbarNav">
-      <!-- 🟢 Liens à gauche -->
-      <ul class="navbar-nav me-auto">
-        <li class="nav-item">
-          <a class="nav-link" href="/<%= locale %>"><%= i18n.menu.home %></a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="/<%= locale %>/contact"><%= i18n.menu.contact %></a>
-        </li>
-      </ul>
+        <!-- Contenu menu -->
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav me-auto">
+            <li class="nav-item">
+              <a class="nav-link" href="/<%= locale %>"><%= i18n.menu.home %></a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/<%= locale %>/contact"><%= i18n.menu.contact %></a>
+            </li>
 
-     <% if (isAuthenticated) { %>
-  <a href="/<%= locale %>/user" class="btn btn-outline-dark rounded-pill px-3 py-1 me-2 d-flex align-items-center gap-2">
-    <i class="bi bi-person-circle"></i>
-    <span><%= locale === 'fr' ? 'Mon compte' : 'My Account' %></span>
-  </a>
-
-  <form action="/logout" method="POST" class="d-inline">
-    <button type="submit" class="btn btn-outline-dark rounded-pill px-3 py-1 d-flex align-items-center gap-2">
-      <i class="bi bi-box-arrow-right"></i>
-      <span><%= locale === 'fr' ? 'Déconnexion' : 'Logout' %></span>
-    </button>
-  </form>
-<% } else { %>
-  <a href="/<%= locale %>/login" class="btn btn-outline-dark rounded-pill px-3 py-1 d-flex align-items-center gap-2">
-    <i class="bi bi-person-fill"></i>
-    <span><%= locale === 'fr' ? 'Connexion' : 'Login' %></span>
-  </a>
-<% } %>
-
-
-
-        <div class="dropdown">
-          <button class="btn btn-light border rounded-pill px-3 py-1 d-flex align-items-center gap-2" type="button"
-            data-bs-toggle="dropdown" aria-expanded="false">
-            <% if (locale === 'fr') { %> 🇫🇷 <% } else { %> 🇬🇧 <% } %>
-            <i class="bi bi-chevron-down small"></i>
-          </button>
-          <ul class="dropdown-menu dropdown-menu-end shadow">
-            <% if (locale === 'fr') { %>
-              <li><a class="dropdown-item d-flex align-items-center gap-2" href="/en<%= currentPath %>">🇬🇧 <span>EN</span></a></li>
+            <% if (isAuthenticated) { %>
+              <!-- Mobile: My Account & Logout -->
+              <li class="nav-item d-lg-none">
+                <a class="nav-link d-flex align-items-center gap-2" href="/<%= locale %>/user">
+                  <i class="bi bi-person-circle"></i>
+                  <%= locale === 'fr' ? 'Mon compte' : 'My Account' %>
+                </a>
+              </li>
+              <li class="nav-item d-lg-none">
+                <form action="/logout" method="POST" class="w-100">
+                  <button type="submit" class="nav-link btn btn-link text-start d-flex align-items-center gap-2 w-100" style="border: none; background: none;">
+                    <i class="bi bi-box-arrow-right"></i>
+                    <%= locale === 'fr' ? 'Déconnexion' : 'Logout' %>
+                  </button>
+                </form>
+              </li>
             <% } else { %>
-              <li><a class="dropdown-item d-flex align-items-center gap-2" href="/fr<%= currentPath %>">🇫🇷 <span>FR</span></a></li>
+              <!-- Mobile: Login -->
+              <li class="nav-item d-lg-none">
+                <a class="nav-link d-flex align-items-center gap-2" href="/<%= locale %>/login">
+                  <i class="bi bi-person-fill"></i>
+                  <%= locale === 'fr' ? 'Connexion' : 'Login' %>
+                </a>
+              </li>
             <% } %>
           </ul>
+
+          <!-- Desktop: Account or Login -->
+          <% if (isAuthenticated) { %>
+            <div class="d-none d-lg-flex align-items-center ms-auto">
+              <a href="/<%= locale %>/user" class="btn btn-outline-dark rounded-pill px-3 py-1 me-2 d-flex align-items-center gap-2">
+                <i class="bi bi-person-circle"></i>
+                <span><%= i18n.menu.my_account %></span>
+              </a>
+              <form action="/logout" method="POST" class="d-inline">
+                <button type="submit" class="btn btn-outline-dark rounded-pill px-3 py-1 d-flex align-items-center gap-2">
+                  <i class="bi bi-box-arrow-right"></i>
+                  <span><%= i18n.menu.logout %></span>
+                </button>
+              </form>
+            </div>
+          <% } else { %>
+            <div class="d-none d-lg-flex align-items-center ms-auto">
+              <a href="/<%= locale %>/login" class="btn btn-outline-dark rounded-pill px-3 py-1 me-3 d-flex align-items-center gap-2">
+                <i class="bi bi-person-fill"></i>
+                <span><%= locale === 'fr' ? 'Connexion' : 'Login' %></span>
+              </a>
+            </div>
+          <% } %>
+
+          <!-- Langue: uniquement desktop -->
+          <div class="desktop-lang-selector ms-3">
+            <div class="dropdown">
+              <button class="btn btn-light border rounded-pill px-3 py-1 d-flex align-items-center gap-2" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                <span class="lang-flag <%= locale === 'fr' ? 'lang-fr' : 'lang-en' %>"></span>
+                <i class="bi bi-chevron-down small"></i>
+              </button>
+              <ul class="dropdown-menu dropdown-menu-end shadow">
+                <% if (locale === 'fr') { %>
+                  <li><a class="dropdown-item d-flex align-items-center gap-2" href="/en<%= cleanPath %>"><span class="lang-flag lang-en"></span> <span>English</span></a></li>
+                <% } else { %>
+                  <li><a class="dropdown-item d-flex align-items-center gap-2" href="/fr<%= cleanPath %>"><span class="lang-flag lang-fr"></span> <span>Français</span></a></li>
+                <% } %>
+              </ul>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-  </div>
-</nav>
+    </nav>
         <section class="new-section">
             <div class="container">
                 <div class="row">


### PR DESCRIPTION
## Summary
- match `forgot-password` navbar markup with the one on `login`
- add missing menu translations used by the navbar

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68409d700f308328999301b47a120e50