### PR TITLE
Add QR code popup button

### DIFF
--- a/locales/en/user.json
+++ b/locales/en/user.json
@@ -106,5 +106,6 @@
   "created_actions": "Actions",
   "redirect_payment": "Redirecting to payment...",
   "url_modal_title": "Page URL",
-  "copy_url": "Copy URL"
+  "copy_url": "Copy URL",
+  "open_page": "Open page"
 }

--- a/locales/fr/user.json
+++ b/locales/fr/user.json
@@ -106,5 +106,6 @@
   "created_actions": "Actions",
   "redirect_payment": "Redirection vers le paiement en cours...",
   "url_modal_title": "URL de la page",
-  "copy_url": "Copier l'URL"
+  "copy_url": "Copier l'URL",
+  "open_page": "Ouvrir la page"
 }

--- a/views/user.ejs
+++ b/views/user.ejs
@@ -552,6 +552,17 @@ progress {
     padding: 0.25em 0.4em;
   }
 
+  .btn-qr {
+    background-color: #40E0D0;
+    color: #fff;
+    border: none;
+  }
+
+  .btn-qr:hover {
+    background-color: #36c8ba;
+    color: #fff;
+  }
+
     </style>
 </head>
 <body id="top">
@@ -1677,9 +1688,12 @@ async function loadLandingPages() {
             <button class="btn btn-sm btn-outline-dark me-1 show-url-btn" data-url="${page.url}" title="Afficher l'URL">
               <i class="bi bi-link-45deg"></i>
             </button>
-            <button class="btn btn-sm ${disabled ? 'btn-warning disabled' : 'btn-dark'} me-1" 
-                    ${disabled ? 'disabled' : ''} 
-                    title="${disabled ? 'Commande active en cours' : 'Diffuser'}" 
+            <button class="btn btn-sm btn-qr me-1 qr-code-btn" data-id="${page._id}" title="QR Code">
+              <i class="bi bi-qr-code"></i>
+            </button>
+            <button class="btn btn-sm ${disabled ? 'btn-warning disabled' : 'btn-dark'} me-1"
+                    ${disabled ? 'disabled' : ''}
+                    title="${disabled ? 'Commande active en cours' : 'Diffuser'}"
                     ${disabled ? '' : `onclick="redirectToPayment('${page._id}')"`}>
               <i class="bi bi-megaphone"></i>
             </button>
@@ -1718,6 +1732,11 @@ async function loadLandingPages() {
         document.getElementById('urlModalText').textContent = url;
         const modal = new bootstrap.Modal(document.getElementById('urlModal'));
         modal.show();
+      });
+    });
+    document.querySelectorAll('.qr-code-btn').forEach(button => {
+      button.addEventListener('click', function () {
+        showQRCode(this.dataset.id);
       });
     });
   } catch (error) {
@@ -1971,10 +1990,21 @@ document.addEventListener("DOMContentLoaded", function () {
   <button type="button" class="btn-close position-absolute top-0 end-0 mt-2 me-2" data-bs-dismiss="modal" aria-label="Fermer"></button>
 </div>
 
-      <div class="modal-body text-center" id="qrCodeContainer">
-        <!-- QR code généré s'affichera ici -->
-        <div class="spinner-border text-primary" role="status">
-          <span class="visually-hidden">Chargement...</span>
+      <div class="modal-body text-center">
+        <div id="qrCodeContainer">
+          <!-- QR code généré s'affichera ici -->
+          <div class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">Chargement...</span>
+          </div>
+        </div>
+        <div id="qrModalActions" class="mt-3">
+          <p id="qrModalUrl" class="text-break small mb-2"></p>
+          <button class="btn btn-sm btn-outline-dark me-1" id="copyQrUrl">
+            <i class="bi bi-clipboard"></i> <%= i18n.copy_url %>
+          </button>
+          <a class="btn btn-sm btn-outline-primary" id="openQrUrl" target="_blank">
+            <i class="bi bi-box-arrow-up-right"></i> <%= i18n.open_page %>
+          </a>
         </div>
       </div>
     </div>
@@ -2004,6 +2034,16 @@ function showQRCode(propertyId) {
       <span class="visually-hidden">Chargement...</span>
     </div>
   `;
+
+  const url = `https://uap.immo/landing-pages/${propertyId}.html`;
+  document.getElementById('qrModalUrl').textContent = url;
+  document.getElementById('openQrUrl').href = url;
+  const copyBtn = document.getElementById('copyQrUrl');
+  copyBtn.onclick = () => {
+    navigator.clipboard.writeText(url).then(() => {
+      showCopyMessage();
+    });
+  };
 
   // Affiche la modale
   const qrModal = new bootstrap.Modal(document.getElementById('qrModal'));


### PR DESCRIPTION
## Summary
- add turquoise QR code button to the Created Pages table
- show QR code modal with share and copy URL actions
- support new `open_page` translation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840b48701b48328a611ccc63cd61e6e