### PR TITLE
Fix repeated icons in landing pages

### DIFF
--- a/routes/add-property.js
+++ b/routes/add-property.js
@@ -77,8 +77,8 @@ async function generateLandingPage(property) {
       <h1>${property.propertyType} à ${city}, ${country}</h1>
       <p>${property.description}</p>
       <p><i class="fal fa-ruler-combined"></i> ${property.surface} m²</p>
-      ${property.rooms ? `<p><span>${'<i class=\\"fal fa-home\\"></i>'.repeat(property.rooms)}</span> ${property.rooms} Pièce${property.rooms > 1 ? 's' : ''}</p>` : ''}
-      ${property.bedrooms ? `<p><span>${'<i class=\\"fal fa-bed\\"></i>'.repeat(property.bedrooms)}</span> ${property.bedrooms} Chambre${property.bedrooms > 1 ? 's' : ''}</p>` : ''}
+      ${property.rooms ? `<p><i class=\\"fal fa-home\\"></i> ${property.rooms}</p>` : ''}
+      ${property.bedrooms ? `<p><i class=\\"fal fa-bed\\"></i> ${property.bedrooms}</p>` : ''}
       ${property.yearBuilt ? `<p><i class=\\"fal fa-calendar-alt\\"></i> ${property.yearBuilt}</p>` : ''}
       ${property.pool ? `<p><i class=\\"fas fa-swimming-pool\\"></i> Piscine</p>` : ''}
       ${property.wateringSystem ? `<p><i class=\\"fas fa-water\\"></i> Arrosage automatique</p>` : ''}

--- a/routes/property.js
+++ b/routes/property.js
@@ -641,12 +641,12 @@ h1 {
     <p>${property.surface} m²</p>
   </div>
   <div class="detail">
-    <span>${'<i class="fal fa-bed"></i>'.repeat(property.bedrooms)}</span>
-    <p>${property.bedrooms} Chambre${property.bedrooms > 1 ? 's' : ''}</p>
+    <i class="fal fa-bed"></i>
+    <p>${property.bedrooms}</p>
   </div>
   <div class="detail">
-    <span>${'<i class="fal fa-home"></i>'.repeat(property.rooms)}</span>
-    <p>${property.rooms} Pièce${property.rooms > 1 ? 's' : ''}</p>
+    <i class="fal fa-home"></i>
+    <p>${property.rooms}</p>
   </div>
 </div>
 

--- a/server.js
+++ b/server.js
@@ -2011,12 +2011,12 @@ h1 {
     <p>${property.surface} m²</p>
   </div>
   <div class="detail">
-    <span>${'<i class="fal fa-bed"></i>'.repeat(property.bedrooms)}</span>
-    <p>${property.bedrooms} Chambre${property.bedrooms > 1 ? 's' : ''}</p>
+    <i class="fal fa-bed"></i>
+    <p>${property.bedrooms}</p>
   </div>
   <div class="detail">
-    <span>${'<i class="fal fa-home"></i>'.repeat(property.rooms)}</span>
-    <p>${property.rooms} Pièce${property.rooms > 1 ? 's' : ''}</p>
+    <i class="fal fa-home"></i>
+    <p>${property.rooms}</p>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- update landing page generators to display a single icon for rooms and bedrooms
- show only icon + number without text

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68415cf992d88328a27170b3d86646e7