### PR TITLE
Update landing page styles

### DIFF
--- a/routes/property.js
+++ b/routes/property.js
@@ -176,7 +176,7 @@ align-items: stretch;
     }
 
     h1 {
-      font-size: 2.5rem;
+      font-size: 2.3rem;
       font-weight: 400;
     }
 
@@ -420,6 +420,10 @@ align-items: stretch;
   margin-bottom: 12px;
 }
 
+  .info-item {
+    margin: 10px 0;
+  }
+
 
   @media screen and (max-width: 768px) {
   html, body {
@@ -454,10 +458,10 @@ align-items: stretch;
     animation: none;
   }
 h1 {
-  font-size: 1.6rem; /* ou adapte selon ton besoin */
-  line-height: 1.3;  /* réduit l'espacement vertical */
+  font-size: 2.3rem;
+  line-height: 1.3;
   font-weight: 500;
-  margin-bottom: 15px; /* ajoute un petit espace avec ce qui suit */
+  margin-bottom: 15px;
 }
 
   .property-info {
@@ -548,7 +552,7 @@ h1 {
 
   .info-item {
     font-size: 1.25rem;
-    margin-bottom: 10px;
+    margin: 10px 0;
   }
 
   .dpe-bar {

--- a/server.js
+++ b/server.js
@@ -1541,7 +1541,7 @@ align-items: stretch;
     }
 
     h1 {
-      font-size: 2.5rem;
+      font-size: 2.3rem;
       font-weight: 400;
     }
 
@@ -1785,6 +1785,10 @@ align-items: stretch;
   margin-bottom: 12px;
 }
 
+  .info-item {
+    margin: 10px 0;
+  }
+
 
     /* Responsive mobile */
 @media screen and (max-width: 768px) {
@@ -1800,10 +1804,10 @@ align-items: stretch;
     gap: 0;
   }
 h1 {
-  font-size: 1.6rem; /* ou adapte selon ton besoin */
-  line-height: 1.3;  /* réduit l'espacement vertical */
+  font-size: 2.3rem;
+  line-height: 1.3;
   font-weight: 500;
-  margin-bottom: 15px; /* ajoute un petit espace avec ce qui suit */
+  margin-bottom: 15px;
 }
 
   .slider {
@@ -1915,7 +1919,7 @@ h1 {
 
   .info-item {
     font-size: 1.25rem;
-    margin-bottom: 10px;
+    margin: 10px 0;
   }
 
   .dpe-bar {


### PR DESCRIPTION
## Summary
- tweak landing page CSS so each `info-item` has vertical spacing
- set `h1` font-size to `2.3rem` on mobile and desktop

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841665c32188328b67b92cc15b7307c