### PR TITLE
Add language option for landing pages

### DIFF
--- a/locales/en/user.json
+++ b/locales/en/user.json
@@ -67,6 +67,7 @@
   "dpe_label": "Energy Performance Diagnosis (DPE)",
   "main_photo": "Main photo",
   "secondary_photo": "Secondary photo",
+  "language_label": "Page language",
   "description_title": "Property description",
   "description_label": "Description",
   "characters": "characters",

--- a/locales/fr/user.json
+++ b/locales/fr/user.json
@@ -67,6 +67,7 @@
   "dpe_label": "Diagnostic de Performance Énergétique (DPE)",
   "main_photo": "Photo principale",
   "secondary_photo": "Photo secondaire",
+  "language_label": "Langue de la page",
   "description_title": "Description du bien",
   "description_label": "Description",
   "characters": "caractères",

--- a/models/Property.js
+++ b/models/Property.js
@@ -30,6 +30,7 @@ postalCode: {
   caretakerHouse: { type: Boolean, default: false },
   electricShutters: { type: Boolean, default: false },
   outdoorLighting: { type: Boolean, default: false },
+  language: { type: String, enum: ['fr', 'en'], default: 'fr' },
   dpe: {
   type: String,
   enum: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'En cours'],

--- a/routes/add-property.js
+++ b/routes/add-property.js
@@ -106,9 +106,9 @@ router.post('/add-property', authMiddleware, upload.fields([
   { name: 'photo2', maxCount: 1 }
 ]), async (req, res) => {
   try {
-   const { price, surface, country, city, postalCode, propertyType, description } = req.body;
+   const { price, surface, country, city, postalCode, propertyType, description, language } = req.body;
 
-  if (!price || !surface || !country || !city || !postalCode || !propertyType || !description) {
+  if (!price || !surface || !country || !city || !postalCode || !propertyType || !description || !language) {
   return res.status(400).json({ error: 'Tous les champs doivent être remplis.' });
 }
 
@@ -146,6 +146,7 @@ postalCode,
       city,
       propertyType,
       description,
+      language: req.body.language || 'fr',
       userId,
       photos: [photo1, photo2]
     });

--- a/routes/property.js
+++ b/routes/property.js
@@ -809,6 +809,7 @@ router.post('/add-property', authMiddleware, upload.fields([
             country,
             dpe: dpe || 'En cours',
     description: description || '',
+            language: req.body.language || 'fr',
             userId: req.user._id,
             photos: [photo1, photo2]
         });

--- a/server.js
+++ b/server.js
@@ -1116,6 +1116,7 @@ postalCode: req.body.postalCode,
       caretakerHouse: req.body.caretakerHouse === 'true',
       electricShutters: req.body.electricShutters === 'true',
       outdoorLighting: req.body.outdoorLighting === 'true',
+      language: req.body.language || 'fr',
       userId: req.user._id,
       dpe: req.body.dpe || 'En cours',
       photos: [req.files.photo1[0].filename, req.files.photo2[0].filename]

--- a/views/user.ejs
+++ b/views/user.ejs
@@ -932,12 +932,23 @@ progress {
       </div>
 
       <!-- Étape 4 -->
-     <div class="form-step d-none" data-step="4">
+      <div class="form-step d-none" data-step="4">
         <h6 class="mb-3"><%= i18n.description_title %></h6>
         <div class="form-group">
           <label for="description"><%= i18n.description_label %> <span style="color:red">*</span></label>
           <textarea class="form-control" id="description" name="description" rows="5" maxlength="820" required></textarea>
           <small id="charCount">0/820 <%= i18n.characters %></small>
+        </div>
+        <div class="form-group mt-3">
+          <label class="d-block"><%= i18n.language_label %> <span style="color:red">*</span></label>
+          <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="language" id="lang-fr" value="fr" required>
+            <label class="form-check-label" for="lang-fr">FR</label>
+          </div>
+          <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="language" id="lang-en" value="en" required>
+            <label class="form-check-label" for="lang-en">EN</label>
+          </div>
         </div>
         <button type="button" class="btn btn-secondary prev-step mt-3 me-2"><%= i18n.previous %></button>
         <button type="submit" class="btn btn-dark py-2 mt-3">


### PR DESCRIPTION
## Summary
- support FR/EN choice for each property
- validate language in property create routes
- include language radio buttons in add property form

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68416a42b5b0832897ba60f6c5d32501