### PR TITLE
Implement language toggle for landing pages

### DIFF
--- a/routes/add-property.js
+++ b/routes/add-property.js
@@ -22,6 +22,33 @@ async function generateLandingPage(property) {
   const lang = property.language || 'fr';
   const city = property.city || '';
   const country = property.country || '';
+
+  const translations = {
+    fr: {
+      propertyIn: 'à',
+      price: 'Prix',
+      pool: 'Piscine',
+      wateringSystem: 'Arrosage automatique',
+      carShelter: 'Abri voiture',
+      parking: 'Parking',
+      caretakerHouse: 'Maison de gardien',
+      electricShutters: 'Stores électriques',
+      outdoorLighting: 'Éclairage extérieur'
+    },
+    en: {
+      propertyIn: 'in',
+      price: 'Price',
+      pool: 'Pool',
+      wateringSystem: 'Watering system',
+      carShelter: 'Car shelter',
+      parking: 'Parking',
+      caretakerHouse: 'Caretaker house',
+      electricShutters: 'Electric shutters',
+      outdoorLighting: 'Outdoor lighting'
+    }
+  };
+
+  const t = translations[lang] || translations.fr;
   const slug = slugify(`${property.propertyType}-${city}-${country}`, { lower: true });
   const filename = `${property._id}-${slug}.html`;
   const filePath = path.join(__dirname, '../public/landing-pages', filename);
@@ -74,20 +101,20 @@ async function generateLandingPage(property) {
     </head>
     <body>
       <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${GTM_ID}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      <h1>${property.propertyType} à ${city}, ${country}</h1>
+      <h1>${property.propertyType} ${t.propertyIn} ${city}, ${country}</h1>
       <p>${property.description}</p>
       <p><i class="fal fa-ruler-combined"></i> ${property.surface} m²</p>
       ${property.rooms ? `<p><i class=\\"fal fa-home\\"></i> ${property.rooms}</p>` : ''}
       ${property.bedrooms ? `<p><i class=\\"fal fa-bed\\"></i> ${property.bedrooms}</p>` : ''}
       ${property.yearBuilt ? `<p><i class=\\"fal fa-calendar-alt\\"></i> ${property.yearBuilt}</p>` : ''}
-      ${property.pool ? `<p><i class=\\"fas fa-swimming-pool\\"></i> Piscine</p>` : ''}
-      ${property.wateringSystem ? `<p><i class=\\"fas fa-water\\"></i> Arrosage automatique</p>` : ''}
-      ${property.carShelter ? `<p><i class=\\"fas fa-car\\"></i> Abri voiture</p>` : ''}
-      ${property.parking ? `<p><i class=\\"fas fa-parking\\"></i> Parking</p>` : ''}
-      ${property.caretakerHouse ? `<p><i class=\\"fas fa-house-user\\"></i> Maison de gardien</p>` : ''}
-      ${property.electricShutters ? `<p><i class=\\"fas fa-window-maximize\\"></i> Stores électriques</p>` : ''}
-      ${property.outdoorLighting ? `<p><i class=\\"fas fa-lightbulb\\"></i> Éclairage extérieur</p>` : ''}
-      <p>Prix : ${Number(property.price).toLocaleString('fr-FR')} €</p>
+      ${property.pool ? `<p><i class=\\"fas fa-swimming-pool\\"></i> ${t.pool}</p>` : ''}
+      ${property.wateringSystem ? `<p><i class=\\"fas fa-water\\"></i> ${t.wateringSystem}</p>` : ''}
+      ${property.carShelter ? `<p><i class=\\"fas fa-car\\"></i> ${t.carShelter}</p>` : ''}
+      ${property.parking ? `<p><i class=\\"fas fa-parking\\"></i> ${t.parking}</p>` : ''}
+      ${property.caretakerHouse ? `<p><i class=\\"fas fa-house-user\\"></i> ${t.caretakerHouse}</p>` : ''}
+      ${property.electricShutters ? `<p><i class=\\"fas fa-window-maximize\\"></i> ${t.electricShutters}</p>` : ''}
+      ${property.outdoorLighting ? `<p><i class=\\"fas fa-lightbulb\\"></i> ${t.outdoorLighting}</p>` : ''}
+      <p>${t.price} : ${Number(property.price).toLocaleString(lang === 'en' ? 'en-US' : 'fr-FR')} €</p>
       <img src="/uploads/${property.photos[0] || 'default.jpg'}" width="400">
     </body>
     </html>`;

--- a/routes/property.js
+++ b/routes/property.js
@@ -34,6 +34,57 @@ async function generateLandingPage(property) {
   const city = property.city || '';
   const country = property.country || '';
 
+  const translations = {
+    fr: {
+      adLabel: 'UAP Immo Annonce',
+      propertyHeading: 'Propriété à',
+      propertyType: 'Type de bien',
+      yearBuilt: 'Année de construction',
+      guidedTour: 'Visite guidée',
+      price: 'Prix',
+      addInfo: 'Informations complémentaires',
+      keyInfo: 'Informations clés',
+      location: 'Localisation',
+      pool: 'Piscine',
+      wateringSystem: 'Arrosage automatique',
+      carShelter: 'Abri voiture',
+      parking: 'Parking',
+      caretakerHouse: 'Maison de gardien',
+      electricShutters: 'Stores électriques',
+      outdoorLighting: 'Éclairage extérieur',
+      notProvided: 'Non renseignée',
+      noDescription: 'Aucune description fournie.',
+      mapUnavailable: 'Carte non disponible.',
+      mapError: 'Erreur lors du chargement de la carte.',
+      inProgress: 'En cours'
+    },
+    en: {
+      adLabel: 'UAP Real Estate Ad',
+      propertyHeading: 'Property in',
+      propertyType: 'Property Type',
+      yearBuilt: 'Year built',
+      guidedTour: 'Guided tour',
+      price: 'Price',
+      addInfo: 'Additional information',
+      keyInfo: 'Key information',
+      location: 'Location',
+      pool: 'Pool',
+      wateringSystem: 'Watering system',
+      carShelter: 'Car shelter',
+      parking: 'Parking',
+      caretakerHouse: 'Caretaker house',
+      electricShutters: 'Electric shutters',
+      outdoorLighting: 'Outdoor lighting',
+      notProvided: 'Not provided',
+      noDescription: 'No description provided.',
+      mapUnavailable: 'Map not available.',
+      mapError: 'Error loading the map.',
+      inProgress: 'In progress'
+    }
+  };
+
+  const t = translations[lang] || translations.fr;
+
   const slug = slugify(`${property.propertyType}-${city}-${country}`, { lower: true });
   const filename = `${property._id}-${slug}.html`;
   const filePath = path.join(__dirname, '../public/landing-pages', filename);
@@ -643,9 +694,9 @@ h1 {
       </div>
     </div>
     <div class="property-info">
-      <p class="property-lorem">UAP Immo Annonce</p>
-      <h1>Propriété à<br> ${property.city}, ${property.country}</h1>
-      <h2>Type de bien: ${property.propertyType}</h2>
+      <p class="property-lorem">${t.adLabel}</p>
+      <h1>${t.propertyHeading}<br> ${property.city}, ${property.country}</h1>
+      <h2>${t.propertyType}: ${property.propertyType}</h2>
       <div class="property-details one-line">
   <div class="detail">
     <i class="fal fa-ruler-combined"></i>
@@ -662,28 +713,28 @@ h1 {
 </div>
 
 
-      <div class="construction-year">Année de construction: ${property.yearBuilt || 'Non renseignée'}</div>
+      <div class="construction-year">${t.yearBuilt}: ${property.yearBuilt || t.notProvided}</div>
 
       <div class="property-description">
-        <div class="section-title">Visite guidée</div>
-        ${property.description || 'Aucune description fournie.'}
+        <div class="section-title">${t.guidedTour}</div>
+        ${property.description || t.noDescription}
       </div>
 
-      <div class="price">Prix: ${Number(property.price).toLocaleString('fr-FR')} €</div>
+      <div class="price">${t.price}: ${Number(property.price).toLocaleString(lang === 'en' ? 'en-US' : 'fr-FR')} €</div>
     </div>
   </div>
 
   <!-- Bloc secondaire en dessous -->
  <div class="extra-info-desktop">
   <hr />
-  <h2>Informations complémentaires</h2>
+  <h2>${t.addInfo}</h2>
 
   <div class="extra-columns">
 <!-- Colonne 1 : DPE -->
 <div class="extra-col">
   <div class="info-label">DPE : ${
     property.dpe.toLowerCase() === 'en cours'
-      ? '<em>En cours</em>'
+      ? `<em>${t.inProgress}</em>`
       : `<strong>${property.dpe}</strong>`
   }</div>
   <div class="dpe-bar">
@@ -697,24 +748,24 @@ h1 {
 
 <!-- Colonne 2 : Informations clés -->
 <div class="extra-col">
-  <div class="info-label">Informations clés</div>
-  <div class="info-item">Prix : ${Number(property.price).toLocaleString('fr-FR')} €</div>
+  <div class="info-label">${t.keyInfo}</div>
+  <div class="info-item">${t.price} : ${Number(property.price).toLocaleString(lang === 'en' ? 'en-US' : 'fr-FR')} €</div>
   <div class="info-item"><i class="fal fa-ruler-combined"></i> ${property.surface} m²</div>
   <div class="info-item"><i class="fal fa-home"></i> ${property.rooms}</div>
   <div class="info-item"><i class="fal fa-bed"></i> ${property.bedrooms}</div>
-  <div class="info-item"><i class="fal fa-calendar-alt"></i> ${property.yearBuilt || 'Non renseignée'}</div>
-  ${property.pool ? `<div class="info-item"><i class="fas fa-swimming-pool"></i> Piscine</div>` : ''}
-  ${property.wateringSystem ? `<div class="info-item"><i class="fas fa-water"></i> Arrosage automatique</div>` : ''}
-  ${property.carShelter ? `<div class="info-item"><i class="fas fa-car"></i> Abri voiture</div>` : ''}
-  ${property.parking ? `<div class="info-item"><i class="fas fa-parking"></i> Parking</div>` : ''}
-  ${property.caretakerHouse ? `<div class="info-item"><i class="fas fa-house-user"></i> Maison de gardien</div>` : ''}
-  ${property.electricShutters ? `<div class="info-item"><i class="fas fa-window-maximize"></i> Stores électriques</div>` : ''}
-  ${property.outdoorLighting ? `<div class="info-item"><i class="fas fa-lightbulb"></i> Éclairage extérieur</div>` : ''}
+  <div class="info-item"><i class="fal fa-calendar-alt"></i> ${property.yearBuilt || t.notProvided}</div>
+  ${property.pool ? `<div class="info-item"><i class="fas fa-swimming-pool"></i> ${t.pool}</div>` : ''}
+  ${property.wateringSystem ? `<div class="info-item"><i class="fas fa-water"></i> ${t.wateringSystem}</div>` : ''}
+  ${property.carShelter ? `<div class="info-item"><i class="fas fa-car"></i> ${t.carShelter}</div>` : ''}
+  ${property.parking ? `<div class="info-item"><i class="fas fa-parking"></i> ${t.parking}</div>` : ''}
+  ${property.caretakerHouse ? `<div class="info-item"><i class="fas fa-house-user"></i> ${t.caretakerHouse}</div>` : ''}
+  ${property.electricShutters ? `<div class="info-item"><i class="fas fa-window-maximize"></i> ${t.electricShutters}</div>` : ''}
+  ${property.outdoorLighting ? `<div class="info-item"><i class="fas fa-lightbulb"></i> ${t.outdoorLighting}</div>` : ''}
 </div>
 
 <!-- Colonne 3 : Localisation -->
 <div class="extra-col map-col">
-  <div class="info-label">Localisation</div>
+  <div class="info-label">${t.location}</div>
   <div id="map"></div>
 </div>
 
@@ -749,12 +800,12 @@ ${JSON.stringify(jsonLD)}
           L.marker([lat, lon]).addTo(map)
             .bindPopup("<b>" + city + "</b><br>" + country).openPopup();
         } else {
-          document.getElementById('map').innerHTML = "Carte non disponible.";
+          document.getElementById('map').innerHTML = "${t.mapUnavailable}";
         }
       })
       .catch(err => {
         console.error(err);
-        document.getElementById('map').innerHTML = "Erreur lors du chargement de la carte.";
+        document.getElementById('map').innerHTML = "${t.mapError}";
       });
   });
 </script>

--- a/server.js
+++ b/server.js
@@ -1400,6 +1400,57 @@ async function generateLandingPage(property) {
   const city = property.city || '';
   const country = property.country || '';
 
+  const translations = {
+    fr: {
+      adLabel: 'UAP Immo Annonce',
+      propertyHeading: 'Propriété à',
+      propertyType: 'Type de bien',
+      yearBuilt: 'Année de construction',
+      guidedTour: 'Visite guidée',
+      price: 'Prix',
+      addInfo: 'Informations complémentaires',
+      keyInfo: 'Informations clés',
+      location: 'Localisation',
+      pool: 'Piscine',
+      wateringSystem: 'Arrosage automatique',
+      carShelter: 'Abri voiture',
+      parking: 'Parking',
+      caretakerHouse: 'Maison de gardien',
+      electricShutters: 'Stores électriques',
+      outdoorLighting: 'Éclairage extérieur',
+      notProvided: 'Non renseignée',
+      noDescription: 'Aucune description fournie.',
+      mapUnavailable: 'Carte non disponible.',
+      mapError: 'Erreur lors du chargement de la carte.',
+      inProgress: 'En cours'
+    },
+    en: {
+      adLabel: 'UAP Real Estate Ad',
+      propertyHeading: 'Property in',
+      propertyType: 'Property Type',
+      yearBuilt: 'Year built',
+      guidedTour: 'Guided tour',
+      price: 'Price',
+      addInfo: 'Additional information',
+      keyInfo: 'Key information',
+      location: 'Location',
+      pool: 'Pool',
+      wateringSystem: 'Watering system',
+      carShelter: 'Car shelter',
+      parking: 'Parking',
+      caretakerHouse: 'Caretaker house',
+      electricShutters: 'Electric shutters',
+      outdoorLighting: 'Outdoor lighting',
+      notProvided: 'Not provided',
+      noDescription: 'No description provided.',
+      mapUnavailable: 'Map not available.',
+      mapError: 'Error loading the map.',
+      inProgress: 'In progress'
+    }
+  };
+
+  const t = translations[lang] || translations.fr;
+
   const slug = slugify(`${property.propertyType}-${city}-${country}`, { lower: true });
   const filename = `${property._id}-${slug}.html`;
   const filePath = path.join(__dirname, 'public/landing-pages', filename);
@@ -2013,9 +2064,9 @@ h1 {
     </div>
 
     <div class="property-info">
-      <p class="property-lorem">UAP Immo Annonce</p>
-      <h1>Propriété à<br> ${property.city}, ${property.country}</h1>
-      <h2>Type de bien: ${property.propertyType}</h2>
+      <p class="property-lorem">${t.adLabel}</p>
+      <h1>${t.propertyHeading}<br> ${property.city}, ${property.country}</h1>
+      <h2>${t.propertyType}: ${property.propertyType}</h2>
 
       <div class="property-details one-line">
   <div class="detail">
@@ -2033,28 +2084,28 @@ h1 {
 </div>
 
 
-      <div class="construction-year">Année de construction: ${property.yearBuilt || 'Non renseignée'}</div>
+      <div class="construction-year">${t.yearBuilt}: ${property.yearBuilt || t.notProvided}</div>
 
       <div class="property-description">
-        <div class="section-title">Visite guidée</div>
-        ${property.description || 'Aucune description fournie.'}
+        <div class="section-title">${t.guidedTour}</div>
+        ${property.description || t.noDescription}
       </div>
 
-      <div class="price">Prix: ${Number(property.price).toLocaleString('fr-FR')} €</div>
+      <div class="price">${t.price}: ${Number(property.price).toLocaleString(lang === 'en' ? 'en-US' : 'fr-FR')} €</div>
     </div>
   </div>
 
   <!-- Bloc secondaire en dessous -->
  <div class="extra-info-desktop">
   <hr />
-  <h2>Informations complémentaires</h2>
+  <h2>${t.addInfo}</h2>
 
   <div class="extra-columns">
 <!-- Colonne 1 : DPE -->
 <div class="extra-col">
   <div class="info-label">DPE : ${
     property.dpe.toLowerCase() === 'en cours'
-      ? '<em>En cours</em>'
+      ? `<em>${t.inProgress}</em>`
       : `<strong>${property.dpe}</strong>`
   }</div>
   <div class="dpe-bar">
@@ -2068,24 +2119,24 @@ h1 {
 
 <!-- Colonne 2 : Informations clés -->
 <div class="extra-col">
-  <div class="info-label">Informations clés</div>
-  <div class="info-item">Prix : ${Number(property.price).toLocaleString('fr-FR')} €</div>
+  <div class="info-label">${t.keyInfo}</div>
+  <div class="info-item">${t.price} : ${Number(property.price).toLocaleString(lang === 'en' ? 'en-US' : 'fr-FR')} €</div>
   <div class="info-item"><i class="fal fa-ruler-combined"></i> ${property.surface} m²</div>
   <div class="info-item"><i class="fal fa-home"></i> ${property.rooms}</div>
   <div class="info-item"><i class="fal fa-bed"></i> ${property.bedrooms}</div>
-  <div class="info-item"><i class="fal fa-calendar-alt"></i> ${property.yearBuilt || 'Non renseignée'}</div>
-  ${property.pool ? `<div class="info-item"><i class="fas fa-swimming-pool"></i> Piscine</div>` : ''}
-  ${property.wateringSystem ? `<div class="info-item"><i class="fas fa-water"></i> Arrosage automatique</div>` : ''}
-  ${property.carShelter ? `<div class="info-item"><i class="fas fa-car"></i> Abri voiture</div>` : ''}
-  ${property.parking ? `<div class="info-item"><i class="fas fa-parking"></i> Parking</div>` : ''}
-  ${property.caretakerHouse ? `<div class="info-item"><i class="fas fa-house-user"></i> Maison de gardien</div>` : ''}
-  ${property.electricShutters ? `<div class="info-item"><i class="fas fa-window-maximize"></i> Stores électriques</div>` : ''}
-  ${property.outdoorLighting ? `<div class="info-item"><i class="fas fa-lightbulb"></i> Éclairage extérieur</div>` : ''}
+  <div class="info-item"><i class="fal fa-calendar-alt"></i> ${property.yearBuilt || t.notProvided}</div>
+  ${property.pool ? `<div class="info-item"><i class="fas fa-swimming-pool"></i> ${t.pool}</div>` : ''}
+  ${property.wateringSystem ? `<div class="info-item"><i class="fas fa-water"></i> ${t.wateringSystem}</div>` : ''}
+  ${property.carShelter ? `<div class="info-item"><i class="fas fa-car"></i> ${t.carShelter}</div>` : ''}
+  ${property.parking ? `<div class="info-item"><i class="fas fa-parking"></i> ${t.parking}</div>` : ''}
+  ${property.caretakerHouse ? `<div class="info-item"><i class="fas fa-house-user"></i> ${t.caretakerHouse}</div>` : ''}
+  ${property.electricShutters ? `<div class="info-item"><i class="fas fa-window-maximize"></i> ${t.electricShutters}</div>` : ''}
+  ${property.outdoorLighting ? `<div class="info-item"><i class="fas fa-lightbulb"></i> ${t.outdoorLighting}</div>` : ''}
 </div>
 
 <!-- Colonne 3 : Localisation -->
 <div class="extra-col map-col">
-  <div class="info-label">Localisation</div>
+  <div class="info-label">${t.location}</div>
   <div id="map"></div>
 </div>
 
@@ -2120,12 +2171,12 @@ ${JSON.stringify(jsonLD)}
           L.marker([lat, lon]).addTo(map)
             .bindPopup("<b>" + city + "</b><br>" + country).openPopup();
         } else {
-          document.getElementById('map').innerHTML = "Carte non disponible.";
+          document.getElementById('map').innerHTML = "${t.mapUnavailable}";
         }
       })
       .catch(err => {
         console.error(err);
-        document.getElementById('map').innerHTML = "Erreur lors du chargement de la carte.";
+        document.getElementById('map').innerHTML = "${t.mapError}";
       });
   });
 </script>


### PR DESCRIPTION
## Summary
- add English/French translation tables in landing page generators
- show translated labels on generated property pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841756a379883288501573bddd89765