### PR TITLE
Make parking field required with yes/no display

### DIFF
--- a/routes/add-property.js
+++ b/routes/add-property.js
@@ -33,7 +33,9 @@ async function generateLandingPage(property) {
       parking: 'Parking',
       caretakerHouse: 'Maison de gardien',
       electricShutters: 'Stores électriques',
-      outdoorLighting: 'Éclairage extérieur'
+      outdoorLighting: 'Éclairage extérieur',
+      yes: 'Oui',
+      no: 'Non'
     },
     en: {
       propertyIn: 'in',
@@ -44,7 +46,9 @@ async function generateLandingPage(property) {
       parking: 'Parking',
       caretakerHouse: 'Caretaker house',
       electricShutters: 'Electric shutters',
-      outdoorLighting: 'Outdoor lighting'
+      outdoorLighting: 'Outdoor lighting',
+      yes: 'Yes',
+      no: 'No'
     },
     es: {
       propertyIn: 'en',
@@ -55,7 +59,9 @@ async function generateLandingPage(property) {
       parking: 'Estacionamiento',
       caretakerHouse: 'Casa del guardián',
       electricShutters: 'Persianas eléctricas',
-      outdoorLighting: 'Iluminación exterior'
+      outdoorLighting: 'Iluminación exterior',
+      yes: 'Sí',
+      no: 'No'
     },
     pt: {
       propertyIn: 'em',
@@ -66,7 +72,9 @@ async function generateLandingPage(property) {
       parking: 'Estacionamento',
       caretakerHouse: 'Casa do zelador',
       electricShutters: 'Persianas elétricas',
-      outdoorLighting: 'Iluminação externa'
+      outdoorLighting: 'Iluminação externa',
+      yes: 'Sim',
+      no: 'Não'
     }
   };
 
@@ -132,7 +140,7 @@ async function generateLandingPage(property) {
       ${property.pool ? `<p><i class=\\"fas fa-swimming-pool\\"></i> ${t.pool}</p>` : ''}
       ${property.wateringSystem ? `<p><i class=\\"fas fa-water\\"></i> ${t.wateringSystem}</p>` : ''}
       ${property.carShelter ? `<p><i class=\\"fas fa-car\\"></i> ${t.carShelter}</p>` : ''}
-      ${property.parking ? `<p><i class=\\"fas fa-parking\\"></i> ${t.parking}</p>` : ''}
+      <p><i class=\\"fas fa-parking\\"></i> ${t.parking}: ${property.parking ? t.yes : t.no}</p>
       ${property.caretakerHouse ? `<p><i class=\\"fas fa-house-user\\"></i> ${t.caretakerHouse}</p>` : ''}
       ${property.electricShutters ? `<p><i class=\\"fas fa-window-maximize\\"></i> ${t.electricShutters}</p>` : ''}
       ${property.outdoorLighting ? `<p><i class=\\"fas fa-lightbulb\\"></i> ${t.outdoorLighting}</p>` : ''}

--- a/routes/property.js
+++ b/routes/property.js
@@ -52,6 +52,8 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Maison de gardien',
       electricShutters: 'Stores électriques',
       outdoorLighting: 'Éclairage extérieur',
+      yes: 'Oui',
+      no: 'Non',
       notProvided: 'Non renseignée',
       noDescription: 'Aucune description fournie.',
       mapUnavailable: 'Carte non disponible.',
@@ -75,6 +77,8 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Caretaker house',
       electricShutters: 'Electric shutters',
       outdoorLighting: 'Outdoor lighting',
+      yes: 'Yes',
+      no: 'No',
       notProvided: 'Not provided',
       noDescription: 'No description provided.',
       mapUnavailable: 'Map not available.',
@@ -98,6 +102,8 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Casa del guardián',
       electricShutters: 'Persianas eléctricas',
       outdoorLighting: 'Iluminación exterior',
+      yes: 'Sí',
+      no: 'No',
       notProvided: 'No especificado',
       noDescription: 'No se proporcionó descripción.',
       mapUnavailable: 'Mapa no disponible.',
@@ -121,6 +127,8 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Casa do zelador',
       electricShutters: 'Persianas elétricas',
       outdoorLighting: 'Iluminação externa',
+      yes: 'Sim',
+      no: 'Não',
       notProvided: 'Não fornecido',
       noDescription: 'Nenhuma descrição fornecida.',
       mapUnavailable: 'Mapa indisponível.',
@@ -803,7 +811,7 @@ h1 {
   ${property.pool ? `<div class="info-item"><i class="fas fa-swimming-pool"></i> ${t.pool}</div>` : ''}
   ${property.wateringSystem ? `<div class="info-item"><i class="fas fa-water"></i> ${t.wateringSystem}</div>` : ''}
   ${property.carShelter ? `<div class="info-item"><i class="fas fa-car"></i> ${t.carShelter}</div>` : ''}
-  ${property.parking ? `<div class="info-item"><i class="fas fa-parking"></i> ${t.parking}</div>` : ''}
+  <div class="info-item"><i class="fas fa-parking"></i> ${t.parking}: ${property.parking ? t.yes : t.no}</div>
   ${property.caretakerHouse ? `<div class="info-item"><i class="fas fa-house-user"></i> ${t.caretakerHouse}</div>` : ''}
   ${property.electricShutters ? `<div class="info-item"><i class="fas fa-window-maximize"></i> ${t.electricShutters}</div>` : ''}
   ${property.outdoorLighting ? `<div class="info-item"><i class="fas fa-lightbulb"></i> ${t.outdoorLighting}</div>` : ''}

--- a/server.js
+++ b/server.js
@@ -1097,6 +1097,9 @@ app.post('/add-property', isAuthenticated, upload.fields([
   { name: 'photo2', maxCount: 1 }
 ]), async (req, res) => {
   try {
+    if (typeof req.body.parking === 'undefined') {
+      return res.status(400).send('Le champ parking est requis.');
+    }
     const property = new Property({
       rooms: req.body.rooms,
       bedrooms: req.body.bedrooms,
@@ -1418,6 +1421,8 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Maison de gardien',
       electricShutters: 'Stores électriques',
       outdoorLighting: 'Éclairage extérieur',
+      yes: 'Oui',
+      no: 'Non',
       notProvided: 'Non renseignée',
       noDescription: 'Aucune description fournie.',
       mapUnavailable: 'Carte non disponible.',
@@ -1441,6 +1446,8 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Caretaker house',
       electricShutters: 'Electric shutters',
       outdoorLighting: 'Outdoor lighting',
+      yes: 'Yes',
+      no: 'No',
       notProvided: 'Not provided',
       noDescription: 'No description provided.',
       mapUnavailable: 'Map not available.',
@@ -1464,6 +1471,8 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Casa del guardián',
       electricShutters: 'Persianas eléctricas',
       outdoorLighting: 'Iluminación exterior',
+      yes: 'Sí',
+      no: 'No',
       notProvided: 'No especificado',
       noDescription: 'No se proporcionó descripción.',
       mapUnavailable: 'Mapa no disponible.',
@@ -1487,6 +1496,8 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Casa do zelador',
       electricShutters: 'Persianas elétricas',
       outdoorLighting: 'Iluminação externa',
+      yes: 'Sim',
+      no: 'Não',
       notProvided: 'Não fornecido',
       noDescription: 'Nenhuma descrição fornecida.',
       mapUnavailable: 'Mapa indisponível.',
@@ -2174,7 +2185,7 @@ h1 {
   ${property.pool ? `<div class="info-item"><i class="fas fa-swimming-pool"></i> ${t.pool}</div>` : ''}
   ${property.wateringSystem ? `<div class="info-item"><i class="fas fa-water"></i> ${t.wateringSystem}</div>` : ''}
   ${property.carShelter ? `<div class="info-item"><i class="fas fa-car"></i> ${t.carShelter}</div>` : ''}
-  ${property.parking ? `<div class="info-item"><i class="fas fa-parking"></i> ${t.parking}</div>` : ''}
+  <div class="info-item"><i class="fas fa-parking"></i> ${t.parking}: ${property.parking ? t.yes : t.no}</div>
   ${property.caretakerHouse ? `<div class="info-item"><i class="fas fa-house-user"></i> ${t.caretakerHouse}</div>` : ''}
   ${property.electricShutters ? `<div class="info-item"><i class="fas fa-window-maximize"></i> ${t.electricShutters}</div>` : ''}
   ${property.outdoorLighting ? `<div class="info-item"><i class="fas fa-lightbulb"></i> ${t.outdoorLighting}</div>` : ''}

--- a/views/user.ejs
+++ b/views/user.ejs
@@ -888,7 +888,7 @@ progress {
             <label for="<%= e.id %>"><%= e.label %>
               <i class="fa fa-question-circle ms-1 text-muted" data-bs-toggle="tooltip" title="Présence ou non de cet équipement."></i>
             </label>
-            <select class="form-control" id="<%= e.id %>" name="<%= e.id %>">
+            <select class="form-control" id="<%= e.id %>" name="<%= e.id %>" <%= e.id === 'parking' ? 'required' : '' %>>
               <option value="false">Non</option>
               <option value="true">Oui</option>
             </select>


### PR DESCRIPTION
## Summary
- require `parking` field in landing page form
- mark parking field as required in user form
- display parking availability using translated Yes/No text
- add translations for `yes` and `no`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68419723f0748328a181d07a3d98c2e6