### PR TITLE
Adjust desktop landing page style

### DIFF
--- a/routes/property.js
+++ b/routes/property.js
@@ -267,11 +267,12 @@ align-items: stretch;
 
    .property-info {
   flex: 0.8;
-  padding: 40px;
+  padding: 0 40px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 100%; 
+  height: 100%;
+  gap: 15px;
 }
 
     .property-lorem {
@@ -283,10 +284,11 @@ align-items: stretch;
     h1 {
       font-size: 2.3rem;
       font-weight: 400;
+      line-height: 1.15;
     }
 
     h2 {
-      font-size: 1.6rem;
+      font-size: 1.4rem;
       font-weight: 300;
     }
 

--- a/server.js
+++ b/server.js
@@ -1636,11 +1636,12 @@ align-items: stretch;
 
    .property-info {
   flex: 0.8;
-  padding: 40px;
+  padding: 0 40px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 100%; 
+  height: 100%;
+  gap: 15px;
 }
 
     .property-lorem {
@@ -1652,10 +1653,11 @@ align-items: stretch;
     h1 {
       font-size: 2.3rem;
       font-weight: 400;
+      line-height: 1.15;
     }
 
     h2 {
-      font-size: 1.6rem;
+      font-size: 1.4rem;
       font-weight: 300;
     }
 


### PR DESCRIPTION
## Summary
- refine property info layout for desktop landing pages
- reduce line-height for page titles
- slightly reduce property type size

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841995401ec83289f6446a4fd91f690