### PR TITLE
Fix PayPal client id

### DIFF
--- a/server.js
+++ b/server.js
@@ -301,7 +301,8 @@ app.get('/:locale/payment', isAuthenticated, async (req, res) => {
             city: property.city,
             country: property.country,
             url: property.url,
-currentPath: req.originalUrl 
+            currentPath: req.originalUrl,
+            PAYPAL_CLIENT_ID: process.env.PAYPAL_CLIENT_ID
         });
     } catch (error) {
         console.error('Error fetching property:', error);

--- a/views/payment.ejs
+++ b/views/payment.ejs
@@ -16,7 +16,7 @@
   <!-- Fin Google Tag Manager -->
 
   <!-- PayPal SDK -->
-<script src="https://www.paypal.com/sdk/js?client-id=Af_yHlmaNojiGZwFdKFuO9ES15YwViMBrOL_H-jiC9Jm-noqCF7-GD2zH6mStpVU24420hq87PaGYhmP&currency=EUR"></script>
+  <script src="https://www.paypal.com/sdk/js?client-id=<%= PAYPAL_CLIENT_ID %>&currency=EUR"></script>
   <!-- CSS -->
   <link href="/css/bootstrap.min.css" rel="stylesheet">
   <link href="/css/styles-main.css" rel="stylesheet">


### PR DESCRIPTION
## Summary
- inject PayPal client id from environment when rendering payment page
- load PayPal SDK using the injected id

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841ff5fa9bc8328b8d40e7b6ab9cec8