### PR TITLE
Fix PayPal order creation

### DIFF
--- a/views/payment.ejs
+++ b/views/payment.ejs
@@ -368,8 +368,12 @@ font-family: Arial, sans-serif; /* même police que le reste du site */
 paypal.Buttons({
   createOrder: function(data, actions) {
     return actions.order.create({
+      intent: 'CAPTURE',
       purchase_units: [{
-        amount: { value: '500.00' }
+        amount: {
+          currency_code: 'EUR',
+          value: '500.00'
+        }
       }]
     });
   },


### PR DESCRIPTION
## Summary
- update PayPal button order creation logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684205a3cd90832890b2bd8e02ce3c16