### PR TITLE
Add visit popup with contact info

### DIFF
--- a/models/Property.js
+++ b/models/Property.js
@@ -30,6 +30,9 @@ postalCode: {
   caretakerHouse: { type: Boolean, default: false },
   electricShutters: { type: Boolean, default: false },
   outdoorLighting: { type: Boolean, default: false },
+  contactFirstName: { type: String },
+  contactLastName: { type: String },
+  contactPhone: { type: String },
   language: { type: String, enum: ['fr', 'en', 'es', 'pt'], default: 'fr' },
   dpe: {
   type: String,

--- a/routes/add-property.js
+++ b/routes/add-property.js
@@ -34,6 +34,7 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Maison de gardien',
       electricShutters: 'Stores électriques',
       outdoorLighting: 'Éclairage extérieur',
+      visit: 'Visiter',
       yes: 'Oui',
       no: 'Non'
     },
@@ -47,6 +48,7 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Caretaker house',
       electricShutters: 'Electric shutters',
       outdoorLighting: 'Outdoor lighting',
+      visit: 'Visit',
       yes: 'Yes',
       no: 'No'
     },
@@ -60,6 +62,7 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Casa del guardián',
       electricShutters: 'Persianas eléctricas',
       outdoorLighting: 'Iluminación exterior',
+      visit: 'Visitar',
       yes: 'Sí',
       no: 'No'
     },
@@ -73,6 +76,7 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Casa do zelador',
       electricShutters: 'Persianas elétricas',
       outdoorLighting: 'Iluminação externa',
+      visit: 'Visitar',
       yes: 'Sim',
       no: 'Não'
     }
@@ -145,6 +149,12 @@ async function generateLandingPage(property) {
       ${property.electricShutters ? `<p><i class=\\"fas fa-window-maximize\\"></i> ${t.electricShutters}</p>` : ''}
       ${property.outdoorLighting ? `<p><i class=\\"fas fa-lightbulb\\"></i> ${t.outdoorLighting}</p>` : ''}
       <p>${t.price} : ${Number(property.price).toLocaleString(lang === 'en' ? 'en-US' : 'fr-FR')} €</p>
+      <button id="visitBtn">${t.visit}</button>
+      <script>
+        document.getElementById('visitBtn').addEventListener('click', function() {
+          alert('${property.contactFirstName || ''} ${property.contactLastName || ''} - ${property.contactPhone || ''}');
+        });
+      </script>
       <img src="/uploads/${property.photos[0] || 'default.jpg'}" width="400">
     </body>
     </html>`;
@@ -203,6 +213,9 @@ postalCode,
       city,
       propertyType,
       description,
+      contactFirstName: req.body.contactFirstName,
+      contactLastName: req.body.contactLastName,
+      contactPhone: req.body.contactPhone,
       language: req.body.language || 'fr',
       userId,
       photos: [photo1, photo2]

--- a/routes/property.js
+++ b/routes/property.js
@@ -52,6 +52,7 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Maison de gardien',
       electricShutters: 'Stores électriques',
       outdoorLighting: 'Éclairage extérieur',
+      visit: 'Visiter',
       yes: 'Oui',
       no: 'Non',
       notProvided: 'Non renseignée',
@@ -77,6 +78,7 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Caretaker house',
       electricShutters: 'Electric shutters',
       outdoorLighting: 'Outdoor lighting',
+      visit: 'Visit',
       yes: 'Yes',
       no: 'No',
       notProvided: 'Not provided',
@@ -102,6 +104,7 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Casa del guardián',
       electricShutters: 'Persianas eléctricas',
       outdoorLighting: 'Iluminación exterior',
+      visit: 'Visitar',
       yes: 'Sí',
       no: 'No',
       notProvided: 'No especificado',
@@ -127,6 +130,7 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Casa do zelador',
       electricShutters: 'Persianas elétricas',
       outdoorLighting: 'Iluminação externa',
+      visit: 'Visitar',
       yes: 'Sim',
       no: 'Não',
       notProvided: 'Não fornecido',
@@ -342,10 +346,39 @@ align-items: stretch;
       flex: 1;
     }
 
-    .lorem-btn {
+    .visit-btn {
       width: 100%;
       margin: 20px 0;
       flex: 1;
+      background-color: #C4B990;
+      color: #fff;
+      border: none;
+      padding: 10px 20px;
+      cursor: pointer;
+    }
+    .visit-modal {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.5);
+      align-items: center;
+      justify-content: center;
+    }
+    .visit-modal-content {
+      background: #fff;
+      padding: 20px;
+      border-radius: 4px;
+      text-align: center;
+      position: relative;
+    }
+    .visit-modal .close {
+      position: absolute;
+      top: 10px;
+      right: 20px;
+      cursor: pointer;
     }
 
     /* Bloc Infos complémentaires */
@@ -637,10 +670,15 @@ h1 {
   box-sizing: border-box;
 }
 
-  .lorem-btn {
+  .visit-btn {
     width: 100%;
     margin: 20px 0;
     flex: 1;
+    background-color: #C4B990;
+    color: #fff;
+    border: none;
+    padding: 10px 20px;
+    cursor: pointer;
   }
 
   .extra-info-desktop {
@@ -803,7 +841,14 @@ h1 {
 
       <div class="price-row">
         <div class="price">${t.price}: ${Number(property.price).toLocaleString(lang === 'en' ? 'en-US' : 'fr-FR')} €</div>
-        <button class="lorem-btn">lorem</button>
+        <button class="visit-btn" id="visitBtn">${t.visit}</button>
+        <div id="visitModal" class="visit-modal">
+          <div class="visit-modal-content">
+            <span id="closeModal" class="close">&times;</span>
+            <p>${property.contactFirstName || ''} ${property.contactLastName || ''}</p>
+            <p>${property.contactPhone || ''}</p>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -891,6 +936,23 @@ ${JSON.stringify(jsonLD)}
         console.error(err);
         document.getElementById('map').innerHTML = "${t.mapError}";
       });
+
+    const visitBtn = document.getElementById('visitBtn');
+    const visitModal = document.getElementById('visitModal');
+    const closeModal = document.getElementById('closeModal');
+    if (visitBtn && visitModal && closeModal) {
+      visitBtn.addEventListener('click', () => {
+        visitModal.style.display = 'flex';
+      });
+      closeModal.addEventListener('click', () => {
+        visitModal.style.display = 'none';
+      });
+      visitModal.addEventListener('click', (e) => {
+        if (e.target === visitModal) {
+          visitModal.style.display = 'none';
+        }
+      });
+    }
   });
 </script>
  </html>

--- a/server.js
+++ b/server.js
@@ -1120,6 +1120,9 @@ postalCode: req.body.postalCode,
       caretakerHouse: req.body.caretakerHouse === 'true',
       electricShutters: req.body.electricShutters === 'true',
       outdoorLighting: req.body.outdoorLighting === 'true',
+      contactFirstName: req.body.contactFirstName,
+      contactLastName: req.body.contactLastName,
+      contactPhone: req.body.contactPhone,
       language: req.body.language || 'fr',
       userId: req.user._id,
       dpe: req.body.dpe || 'En cours',
@@ -1422,6 +1425,7 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Maison de gardien',
       electricShutters: 'Stores électriques',
       outdoorLighting: 'Éclairage extérieur',
+      visit: 'Visiter',
       yes: 'Oui',
       no: 'Non',
       notProvided: 'Non renseignée',
@@ -1447,6 +1451,7 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Caretaker house',
       electricShutters: 'Electric shutters',
       outdoorLighting: 'Outdoor lighting',
+      visit: 'Visit',
       yes: 'Yes',
       no: 'No',
       notProvided: 'Not provided',
@@ -1472,6 +1477,7 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Casa del guardián',
       electricShutters: 'Persianas eléctricas',
       outdoorLighting: 'Iluminación exterior',
+      visit: 'Visitar',
       yes: 'Sí',
       no: 'No',
       notProvided: 'No especificado',
@@ -1497,6 +1503,7 @@ async function generateLandingPage(property) {
       caretakerHouse: 'Casa do zelador',
       electricShutters: 'Persianas elétricas',
       outdoorLighting: 'Iluminação externa',
+      visit: 'Visitar',
       yes: 'Sim',
       no: 'Não',
       notProvided: 'Não fornecido',
@@ -2103,6 +2110,38 @@ h1 {
   align-items: flex-start;
 }
 
+    .visit-btn {
+      background-color: #C4B990;
+      color: #fff;
+      border: none;
+      padding: 10px 20px;
+      cursor: pointer;
+      margin-top: 10px;
+    }
+    .visit-modal {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.5);
+      align-items: center;
+      justify-content: center;
+    }
+    .visit-modal-content {
+      background: #fff;
+      padding: 20px;
+      border-radius: 4px;
+      text-align: center;
+    }
+    .visit-modal .close {
+      position: absolute;
+      top: 10px;
+      right: 20px;
+      cursor: pointer;
+    }
+
 
     }
   </style>
@@ -2152,6 +2191,14 @@ h1 {
       </div>
 
       <div class="price">${t.price}: ${Number(property.price).toLocaleString(lang === 'en' ? 'en-US' : 'fr-FR')} €</div>
+      <button class="visit-btn" id="visitBtn">${t.visit}</button>
+      <div id="visitModal" class="visit-modal">
+        <div class="visit-modal-content">
+          <span id="closeModal" class="close">&times;</span>
+          <p>${property.contactFirstName || ''} ${property.contactLastName || ''}</p>
+          <p>${property.contactPhone || ''}</p>
+        </div>
+      </div>
     </div>
   </div>
 
@@ -2238,6 +2285,23 @@ ${JSON.stringify(jsonLD)}
         console.error(err);
         document.getElementById('map').innerHTML = "${t.mapError}";
       });
+    const visitBtn = document.getElementById('visitBtn');
+    const visitModal = document.getElementById('visitModal');
+    const closeModal = document.getElementById('closeModal');
+
+    if (visitBtn && visitModal && closeModal) {
+      visitBtn.addEventListener('click', () => {
+        visitModal.style.display = 'flex';
+      });
+      closeModal.addEventListener('click', () => {
+        visitModal.style.display = 'none';
+      });
+      visitModal.addEventListener('click', (e) => {
+        if (e.target === visitModal) {
+          visitModal.style.display = 'none';
+        }
+      });
+    }
   });
 </script>
  </html>

--- a/views/user.ejs
+++ b/views/user.ejs
@@ -945,6 +945,20 @@ progress {
           <textarea class="form-control" id="description" name="description" rows="5" maxlength="820" required></textarea>
           <small id="charCount">0/820 <%= i18n.characters %></small>
         </div>
+        <div class="row mt-3">
+          <div class="col-md-4">
+            <label for="contactFirstName">Prénom</label>
+            <input type="text" class="form-control" id="contactFirstName" name="contactFirstName">
+          </div>
+          <div class="col-md-4">
+            <label for="contactLastName">Nom</label>
+            <input type="text" class="form-control" id="contactLastName" name="contactLastName">
+          </div>
+          <div class="col-md-4">
+            <label for="contactPhone">Téléphone</label>
+            <input type="text" class="form-control" id="contactPhone" name="contactPhone">
+          </div>
+        </div>
         <div class="form-group mt-3">
           <label class="d-block"><%= i18n.language_label %> <span style="color:red">*</span></label>
           <div class="form-check form-check-inline">


### PR DESCRIPTION
## Summary
- add contact fields to Property model
- capture contact info when saving a property
- show visit button on generated landing pages with popup showing contact info
- allow entering contact details in the property creation form

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842de4a8bf08328b6287044d27b087b