### PR TITLE
Add visit button next to price

### DIFF
--- a/routes/add-property.js
+++ b/routes/add-property.js
@@ -148,8 +148,10 @@ async function generateLandingPage(property) {
       ${property.caretakerHouse ? `<p><i class=\\"fas fa-house-user\\"></i> ${t.caretakerHouse}</p>` : ''}
       ${property.electricShutters ? `<p><i class=\\"fas fa-window-maximize\\"></i> ${t.electricShutters}</p>` : ''}
       ${property.outdoorLighting ? `<p><i class=\\"fas fa-lightbulb\\"></i> ${t.outdoorLighting}</p>` : ''}
-      <p>${t.price} : ${Number(property.price).toLocaleString(lang === 'en' ? 'en-US' : 'fr-FR')} €</p>
-      <button id="visitBtn">${t.visit}</button>
+      <div style="display:flex;align-items:center;gap:10px;">
+        <p style="margin:0;">${t.price} : ${Number(property.price).toLocaleString(lang === 'en' ? 'en-US' : 'fr-FR')} €</p>
+        <button id="visitBtn">${t.visit}</button>
+      </div>
       <script>
         document.getElementById('visitBtn').addEventListener('click', function() {
           alert('${property.contactFirstName || ''} ${property.contactLastName || ''} - ${property.contactPhone || ''}');


### PR DESCRIPTION
## Summary
- show the visit button right beside the price on the landing pages created from `add-property`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842e1c20e90832893e649bc0307e26e