### PR TITLE
Escape carousel transform template literal

### DIFF
--- a/server.js
+++ b/server.js
@@ -2434,7 +2434,7 @@ ${JSON.stringify(jsonLD)}
       let index = 0;
       function updateCarousel() {
         const imgWidth = track.querySelector('img').clientWidth;
-        track.style.transform = `translateX(-${index * imgWidth}px)`;
+        track.style.transform = \`translateX(-\${index * imgWidth}px)\`;
       }
       next.addEventListener('click', () => {
         const visible = window.innerWidth <= 768 ? 2 : 4;


### PR DESCRIPTION
## Summary
- properly escape carousel transform statement inside HTML template to prevent syntax errors during server-side rendering

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a24d5d72b88328a71ea362f0564638