### PR TITLE
fix server crash from property route

### DIFF
--- a/routes/property.js
+++ b/routes/property.js
@@ -1011,7 +1011,7 @@ ${JSON.stringify(jsonLD)}
       let index = 0;
       function updateCarousel() {
         const imgWidth = track.querySelector('img').clientWidth;
-        track.style.transform = `translateX(-${index * imgWidth}px)`;
+        track.style.transform = \`translateX(-\${index * imgWidth}px)\`;
       }
       next.addEventListener('click', () => {
         const visible = window.innerWidth <= 768 ? 2 : 4;


### PR DESCRIPTION
## Summary
- escape nested template literals in property routes to avoid syntax error during server startup

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js` *(fails: querySrv ENOTFOUND _mongodb._tcp.uap-immo.ss4shqp.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dab1732c83289d0f48fa9e30adf1