### PR TITLE
Align photo carousel with container spacing

### DIFF
--- a/routes/property.js
+++ b/routes/property.js
@@ -806,12 +806,16 @@ h1 {
 
     .photo-carousel {
       position: relative;
+      max-width: 1400px;
       width: 100%;
       margin: 20px auto;
+      padding: 0 20px;
       overflow: hidden;
     }
     .photo-carousel .carousel-track {
       display: flex;
+      width: 100%;
+      gap: 30px;
       transition: transform 0.3s ease-in-out;
     }
     .photo-carousel img {

--- a/server.js
+++ b/server.js
@@ -2208,12 +2208,16 @@ h1 {
 
     .photo-carousel {
       position: relative;
+      max-width: 1400px;
       width: 100%;
       margin: 20px auto;
+      padding: 0 20px;
       overflow: hidden;
     }
     .photo-carousel .carousel-track {
       display: flex;
+      width: 100%;
+      gap: 30px;
       transition: transform 0.3s ease-in-out;
     }
     .photo-carousel img {


### PR DESCRIPTION
## Summary
- Ensure landing page photo carousel matches container width and padding
- Add gap between carousel images for consistent spacing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a30853ea1883288ecf27e439e4b9d0