### PR TITLE
feat: add bitcoin payment support

### DIFF
--- a/locales/en/payment.json
+++ b/locales/en/payment.json
@@ -29,6 +29,8 @@
   "price": "Price",
   "total": "Total",
   "pay_with_paypal": "Pay with PayPal",
+  "pay_with_btc": "Pay with Bitcoin",
+  "payment_method": "Payment Method",
   "footer": {
     "informations": "Information",
     "create_account": "Create an Account",

--- a/locales/fr/payment.json
+++ b/locales/fr/payment.json
@@ -29,6 +29,8 @@
   "price": "Prix",
   "total": "Total",
   "pay_with_paypal": "Paiement",
+  "pay_with_btc": "Payer en Bitcoin",
+  "payment_method": "Paiement",
   "footer": {
     "informations": "Informations",
     "create_account": "Créer un compte",

--- a/models/Order.js
+++ b/models/Order.js
@@ -12,6 +12,11 @@ const orderSchema = new mongoose.Schema({
     unique: true,
     sparse: true
   },
+  btcPayInvoiceId: {
+    type: String,
+    unique: true,
+    sparse: true
+  },
   userId: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',

--- a/views/payment.ejs
+++ b/views/payment.ejs
@@ -301,6 +301,7 @@ font-family: Arial, sans-serif; /* même police que le reste du site */
 <p class="form-text"><%= i18n.payment_description_3 %></p>
 <p class="form-text"><em><%= i18n.confirmation_notice %></em></p>
           <div id="paypal-button-container"></div>
+          <button id="btc-button" class="btn btn-warning mt-3"><%= i18n.pay_with_btc %></button>
           <input type="hidden" id="propertyId" value="<%= propertyId %>">
         </div>
       </div>
@@ -311,7 +312,7 @@ font-family: Arial, sans-serif; /* même police que le reste du site */
  <p><strong><%= i18n.duration %>:</strong> 90 days</p>
 <p><strong>ID :</strong> <%= propertyId %></p>
 <p><strong><%= i18n.total %> :</strong> 500€</p>
-<p><strong><%= i18n.pay_with_paypal || 'Paiement' %> :</strong> PayPal</p>
+<p><strong><%= i18n.payment_method %> :</strong> <span id="payment-method">PayPal</span></p>
 </div>
 
         </div>
@@ -359,6 +360,19 @@ font-family: Arial, sans-serif; /* même police que le reste du site */
 </p>
   </div>
 </footer>
+<div class="modal fade" id="btcpay-modal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title"><%= i18n.pay_with_btc %></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body p-0">
+        <iframe id="btcpay-iframe" src="" style="width:100%;height:600px;border:0;"></iframe>
+      </div>
+    </div>
+  </div>
+</div>
    <script src="/js/bootstrap.bundle.min.js"></script>
 <script>
 paypal.Buttons({
@@ -401,6 +415,35 @@ paypal.Buttons({
     });
   }
 }).render('#paypal-button-container');
+
+document.getElementById('btc-button').addEventListener('click', function() {
+  document.getElementById('payment-method').textContent = '<%= i18n.pay_with_btc %>';
+  const propertyId = document.getElementById('propertyId').value;
+
+  fetch('/process-btcpay-payment', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      propertyId: propertyId,
+      amount: '500.00'
+    })
+  })
+  .then(res => res.json())
+  .then(result => {
+    if (result.success && result.invoiceUrl) {
+      const iframe = document.getElementById('btcpay-iframe');
+      iframe.src = result.invoiceUrl;
+      const modal = new bootstrap.Modal(document.getElementById('btcpay-modal'));
+      modal.show();
+    } else {
+      alert('Erreur : ' + result.message);
+    }
+  })
+  .catch(err => {
+    console.error('Erreur BTC Pay:', err);
+    alert("Une erreur s'est produite avec Bitcoin.");
+  });
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Bitcoin payment option and translations
- handle BTC Pay invoices and webhook for email confirmation
- display BTC Pay invoice in on-page modal instead of redirect

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b188548e948328aa9cfdfd93d47299